### PR TITLE
feat: use node20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -9,5 +9,5 @@ inputs:
     description: 'Token for the github API'
     required: true
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'lib/main.js'

--- a/action.yml
+++ b/action.yml
@@ -9,5 +9,5 @@ inputs:
     description: 'Token for the github API'
     required: true
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'lib/main.js'


### PR DESCRIPTION
Currently see the following warning:

> The following actions uses node12 which is deprecated and will be forced to run on node16: tgymnich/publish-github-action@v1. For more info: https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/

---

Edit 2/8/24 - using `node20` now https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/

closes #98 